### PR TITLE
Fix crash calling epicsTypeString() c-string value=NULL

### DIFF
--- a/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
@@ -542,7 +542,7 @@ DataElementUaSdk::readArray (char *value, const epicsUInt32 len,
 
     ProcessReason nReason;
     std::shared_ptr<UpdateUaSdk> upd = incomingQueue.popUpdate(&nReason);
-    dbgReadArray(upd.get(), num, epicsTypeString(*value));
+    dbgReadArray(upd.get(), num, epicsTypeString(value));
 
     switch (upd->getType()) {
     case ProcessReason::readFailure:
@@ -571,7 +571,7 @@ DataElementUaSdk::readArray (char *value, const epicsUInt32 len,
                     ret = 1;
                 } else if (data.type() != expectedType) {
                     errlogPrintf("%s : incoming data type (%s) does not match EPICS array type (%s)\n",
-                                 prec->name, variantTypeString(data.type()), epicsTypeString(*value));
+                                 prec->name, variantTypeString(data.type()), epicsTypeString(value));
                     (void) recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
                     ret = 1;
                 } else {
@@ -1040,7 +1040,7 @@ DataElementUaSdk::writeArray (const char **value, const epicsUInt32 len,
                      prec->name,
                      variantTypeString(incomingData.type()),
                      variantTypeString(targetType),
-                     epicsTypeString(**value));
+                     epicsTypeString(*value));
         (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
         ret = 1;
     } else {
@@ -1067,7 +1067,7 @@ DataElementUaSdk::writeArray (const char **value, const epicsUInt32 len,
             markAsDirty();
         }
 
-        dbgWriteArray(num, epicsTypeString(**value));
+        dbgWriteArray(num, epicsTypeString(*value));
     }
     return ret;
 }

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.h
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.h
@@ -45,7 +45,7 @@ inline const char *epicsTypeString (const epicsInt64 &) { return "epicsInt64"; }
 inline const char *epicsTypeString (const epicsUInt64 &) { return "epicsUInt64"; }
 inline const char *epicsTypeString (const epicsFloat32 &) { return "epicsFloat32"; }
 inline const char *epicsTypeString (const epicsFloat64 &) { return "epicsFloat64"; }
-inline const char *epicsTypeString (const char* &) { return "epicsString"; }
+inline const char *epicsTypeString (const char*) { return "epicsString"; }
 
 inline const char *
 variantTypeString (const OpcUa_BuiltInType type)

--- a/devOpcuaSup/open62541/DataElementOpen62541.cpp
+++ b/devOpcuaSup/open62541/DataElementOpen62541.cpp
@@ -624,7 +624,7 @@ DataElementOpen62541::readArray (char *value, const epicsUInt32 len,
 
     ProcessReason nReason;
     std::shared_ptr<UpdateOpen62541> upd = incomingQueue.popUpdate(&nReason);
-    dbgReadArray(upd.get(), num, epicsTypeString(*value));
+    dbgReadArray(upd.get(), num, epicsTypeString(value));
 
     switch (upd->getType()) {
     case ProcessReason::readFailure:
@@ -653,7 +653,7 @@ DataElementOpen62541::readArray (char *value, const epicsUInt32 len,
                     ret = 1;
                 } else if (data.type != expectedType) {
                     errlogPrintf("%s : incoming data type (%s) does not match EPICS array type (%s)\n",
-                                 prec->name, variantTypeString(data), epicsTypeString(*value));
+                                 prec->name, variantTypeString(data), epicsTypeString(value));
                     (void) recGblSetSevr(prec, READ_ALARM, INVALID_ALARM);
                     ret = 1;
                 } else {
@@ -1048,7 +1048,7 @@ DataElementOpen62541::writeArray (const char **value, const epicsUInt32 len,
                      prec->name,
                      variantTypeString(incomingData),
                      variantTypeString(targetType),
-                     epicsTypeString(**value));
+                     epicsTypeString(*value));
         (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
         ret = 1;
     } else {
@@ -1084,7 +1084,7 @@ DataElementOpen62541::writeArray (const char **value, const epicsUInt32 len,
                 (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
                 ret = 1;
             } else {
-                dbgWriteArray(num, epicsTypeString(**value));
+                dbgWriteArray(num, epicsTypeString(*value));
             }
         }
     }

--- a/devOpcuaSup/open62541/DataElementOpen62541.h
+++ b/devOpcuaSup/open62541/DataElementOpen62541.h
@@ -53,7 +53,7 @@ inline const char *epicsTypeString (const epicsInt64 &) { return "epicsInt64"; }
 inline const char *epicsTypeString (const epicsUInt64 &) { return "epicsUInt64"; }
 inline const char *epicsTypeString (const epicsFloat32 &) { return "epicsFloat32"; }
 inline const char *epicsTypeString (const epicsFloat64 &) { return "epicsFloat64"; }
-inline const char *epicsTypeString (const char* &) { return "epicsString"; }
+inline const char *epicsTypeString (const char*) { return "epicsString"; }
 
 inline const char *
 variantTypeString (const UA_DataType *type)


### PR DESCRIPTION
When compiled without optimization, this caused crashes. Optimization always removed the call with the NULL dereference, as only the argument type is used to select the overloaded function.