### PR TITLE
fix connection state handling

### DIFF
--- a/devOpcuaSup/Item.h
+++ b/devOpcuaSup/Item.h
@@ -16,23 +16,9 @@
 #include <epicsTypes.h>
 #include <epicsTime.h>
 
+#include "devOpcua.h"
+
 namespace DevOpcua {
-
-/**
- * @brief Enum for the EPICS related state of an OPC UA item
- */
-enum ConnectionStatus { down, initialRead, initialWrite, up };
-
-inline const char *
-connectionStatusString (const ConnectionStatus status) {
-    switch(status) {
-    case down:         return "down";
-    case initialRead:  return "initialRead";
-    case initialWrite: return "initialWrite";
-    case up:           return "up";
-    }
-    return "Illegal Value";
-}
 
 struct linkInfo;
 class RecordConnector;
@@ -82,13 +68,6 @@ public:
                            char *text = nullptr,
                            const epicsUInt32 len = 0,
                            epicsTimeStamp *ts = nullptr) = 0;
-
-    /**
-     * @brief Get the EPICS-related state of the item.
-     *
-     * @return connection state (EPICS-related)
-     */
-    virtual ConnectionStatus state() const = 0;
 
     /**
      * @brief Set the EPICS-related state of the item.

--- a/devOpcuaSup/RecordConnector.h
+++ b/devOpcuaSup/RecordConnector.h
@@ -85,8 +85,8 @@ public:
         return pdataelement->writeArray(val, len, num, prec);
     }
 
-    ConnectionStatus state() const { return pitem->state(); }
-    void setState(ConnectionStatus state) { pitem->setState(state); }
+    ConnectionStatus state() const { return connState; }
+    void setState(ConnectionStatus state) { connState = state; }
 
     void
     getStatus(epicsUInt32 *code, char *text, const epicsUInt32 len, epicsTimeStamp *ts = nullptr)
@@ -145,6 +145,7 @@ public:
     std::shared_ptr<DataElement> pdataelement;
     IOSCANPVT ioscanpvt;
     ProcessReason reason;
+    ConnectionStatus connState = ConnectionStatus::down;
 
 private:
     dbCommon *prec;

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
@@ -117,9 +117,9 @@ DataElementUaSdk::setIncomingData(const UaVariant &value,
     incomingData = value;
 
     if (isLeaf()) {
-        if ((pitem->state() == ConnectionStatus::initialRead
+        if ((pconnector->state() == ConnectionStatus::initialRead
              && (reason == ProcessReason::readComplete || reason == ProcessReason::readFailure))
-            || (pitem->state() == ConnectionStatus::up)) {
+            || (pconnector->state() == ConnectionStatus::up)) {
             Guard(pconnector->lock);
             bool wasFirst = false;
             // Make a copy of the value for this element and put it on the queue
@@ -245,6 +245,20 @@ DataElementUaSdk::setIncomingEvent (ProcessReason reason)
             elementMap.clear();
             timesrc = -1;
             mapped = false;
+        }
+    }
+}
+
+void
+DataElementUaSdk::setState(const ConnectionStatus state)
+{
+    if (isLeaf()) {
+        Guard(pconnector->lock);
+        pconnector->setState(state);
+    } else {
+        for (auto &it : elements) {
+            auto pelem = it.lock();
+            pelem->setState(state);
         }
     }
 }

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.h
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.h
@@ -250,6 +250,11 @@ public:
     void setIncomingEvent(ProcessReason reason);
 
     /**
+     * @brief Set the EPICS-related state of the element and all sub-elements.
+     */
+    void setState(const ConnectionStatus state);
+
+    /**
      * @brief Get the outgoing data value from the DataElement.
      *
      * Called from the OPC UA client worker thread when data is being

--- a/devOpcuaSup/UaSdk/ItemUaSdk.h
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.h
@@ -94,17 +94,12 @@ public:
                            char *text = nullptr,
                            const epicsUInt32 len = 0,
                            epicsTimeStamp *ts = nullptr) override;
-    /**
-     * @brief Get the EPICS-related state of the item.
-     * See DevOpcua::Item::state
-     */
-    virtual ConnectionStatus state() const override { return connState; }
 
     /**
      * @brief Set the EPICS-related state of the item.
      * See DevOpcua::Item::setState
      */
-    virtual void setState(const ConnectionStatus state) override { connState = state; }
+    virtual void setState(const ConnectionStatus state) override;
 
     /**
      * @brief Return registered status.
@@ -231,7 +226,6 @@ private:
     bool dataTreeDirty;                    /**< true if any element has been modified */
     UaStatusCode lastStatus;               /**< status code of most recent service */
     ProcessReason lastReason;              /**< most recent processing reason */
-    ConnectionStatus connState;            /**< Connection state of the item */
     epicsTime tsClient;                    /**< client (local) time stamp */
     epicsTime tsServer;                    /**< server time stamp */
     epicsTime tsSource;                    /**< source time stamp */

--- a/devOpcuaSup/devOpcua.cpp
+++ b/devOpcuaSup/devOpcua.cpp
@@ -1247,6 +1247,7 @@ opcua_action_item(REC *prec)
         }
         pcon->getStatus(&prec->statcode, prec->stattext, MAX_STRING_SIZE + 1, &prec->time);
         traceItemActionPrint(pdbc, pcon, ret, action, prec->statcode, prec->stattext);
+        manageStateAndBiniProcessing(pcon);
     }
     CATCH()
     return ret;

--- a/devOpcuaSup/devOpcua.h
+++ b/devOpcuaSup/devOpcua.h
@@ -137,6 +137,22 @@ processReasonString (const ProcessReason type)
     return "Illegal Value";
 }
 
+/**
+ * @brief Enum for the per-record connection state
+ */
+enum ConnectionStatus { down, initialRead, initialWrite, up };
+
+inline const char *
+connectionStatusString (const ConnectionStatus status) {
+    switch(status) {
+    case down:         return "down";
+    case initialRead:  return "initialRead";
+    case initialWrite: return "initialWrite";
+    case up:           return "up";
+    }
+    return "Illegal Value";
+}
+
 template<typename R>
 struct dset6 {
     long N;

--- a/devOpcuaSup/open62541/DataElementOpen62541.cpp
+++ b/devOpcuaSup/open62541/DataElementOpen62541.cpp
@@ -218,9 +218,9 @@ DataElementOpen62541::setIncomingData (const UA_Variant &value,
     UA_Variant_copy(&value, &incomingData);
 
     if (isLeaf()) {
-        if ((pitem->state() == ConnectionStatus::initialRead
+        if ((pconnector->state() == ConnectionStatus::initialRead
              && (reason == ProcessReason::readComplete || reason == ProcessReason::readFailure))
-            || (pitem->state() == ConnectionStatus::up)) {
+            || (pconnector->state() == ConnectionStatus::up)) {
 
             Guard(pconnector->lock);
             bool wasFirst = false;
@@ -310,6 +310,20 @@ DataElementOpen62541::setIncomingEvent (ProcessReason reason)
         for (auto &it : elements) {
             auto pelem = it.lock();
             pelem->setIncomingEvent(reason);
+        }
+    }
+}
+
+void
+DataElementOpen62541::setState(const ConnectionStatus state)
+{
+    if (isLeaf()) {
+        Guard(pconnector->lock);
+        pconnector->setState(state);
+    } else {
+        for (auto &it : elements) {
+            auto pelem = it.lock();
+            pelem->setState(state);
         }
     }
 }

--- a/devOpcuaSup/open62541/DataElementOpen62541.h
+++ b/devOpcuaSup/open62541/DataElementOpen62541.h
@@ -318,6 +318,11 @@ public:
     void setIncomingEvent(ProcessReason reason);
 
     /**
+     * @brief Set the EPICS-related state of the element and all sub-elements.
+     */
+    void setState(const ConnectionStatus state);
+
+    /**
      * @brief Get the outgoing data value from the DataElement.
      *
      * Called from the OPC UA client worker thread when data is being

--- a/devOpcuaSup/open62541/ItemOpen62541.h
+++ b/devOpcuaSup/open62541/ItemOpen62541.h
@@ -88,17 +88,12 @@ public:
                            char *text = nullptr,
                            const epicsUInt32 len = 0,
                            epicsTimeStamp *ts = nullptr) override;
-    /**
-     * @brief Get the EPICS-related state of the item.
-     * See DevOpcua::Item::state
-     */
-    virtual ConnectionStatus state() const override { return connState; }
 
     /**
      * @brief Set the EPICS-related state of the item.
      * See DevOpcua::Item::setState
      */
-    virtual void setState(const ConnectionStatus state) override { connState = state; }
+    virtual void setState(const ConnectionStatus state) override;
 
     /**
      * @brief Return registered status.
@@ -226,7 +221,6 @@ private:
     bool dataTreeDirty;                    /**< true if any element has been modified */
     UA_StatusCode lastStatus;              /**< status code of most recent service */
     ProcessReason lastReason;              /**< most recent processing reason */
-    ConnectionStatus connState;            /**< Connection state of the item */
     epicsTime tsClient;                    /**< client (local) time stamp */
     epicsTime tsServer;                    /**< server time stamp */
     epicsTime tsSource;                    /**< source time stamp */


### PR DESCRIPTION
Each record sets its own ConnectionStatus, but each Item sets ConnectionStatus down the element tree.
Fixes #161.
