### PR TITLE
fix arrayWrite for arrays of strings

### DIFF
--- a/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.cpp
@@ -1051,7 +1051,7 @@ DataElementUaSdk::dbgWriteArray (const epicsUInt32 targetSize, const std::string
 
 // Write array for EPICS String / OpcUa_String
 long
-DataElementUaSdk::writeArray (const char **value, const epicsUInt32 len,
+DataElementUaSdk::writeArray (const char *value, const epicsUInt32 len,
                               const epicsUInt32 num,
                               OpcUa_BuiltInType targetType,
                               dbCommon *prec)
@@ -1067,7 +1067,7 @@ DataElementUaSdk::writeArray (const char **value, const epicsUInt32 len,
                      prec->name,
                      variantTypeString(incomingData.type()),
                      variantTypeString(targetType),
-                     epicsTypeString(*value));
+                     epicsTypeString(value));
         (void) recGblSetSevr(prec, WRITE_ALARM, INVALID_ALARM);
         ret = 1;
     } else {
@@ -1077,16 +1077,17 @@ DataElementUaSdk::writeArray (const char **value, const epicsUInt32 len,
             char *val = nullptr;
             const char *pval;
             // add zero termination if necessary
-            if (memchr(value[i], '\0', len) == nullptr) {
+            if (value[len-1] != '\0') {
                 val = new char[len+1];
-                strncpy(val, value[i], len);
+                strncpy(val, value, len);
                 val[len] = '\0';
                 pval = val;
             } else {
-                pval = value[i];
+                pval = value;
             }
             UaString(pval).copyTo(&arr[i]);
             delete[] val;
+            value += len;
         }
         { // Scope of Guard G
             Guard G(outgoingLock);
@@ -1094,7 +1095,7 @@ DataElementUaSdk::writeArray (const char **value, const epicsUInt32 len,
             markAsDirty();
         }
 
-        dbgWriteArray(num, epicsTypeString(*value));
+        dbgWriteArray(num, epicsTypeString(value));
     }
     return ret;
 }
@@ -1198,7 +1199,7 @@ DataElementUaSdk::writeArray (const epicsFloat64 *value, const epicsUInt32 num, 
 long
 DataElementUaSdk::writeArray (const char *value, const epicsUInt32 len, const epicsUInt32 num, dbCommon *prec)
 {
-    return writeArray(&value, len, num, OpcUaType_String, prec);
+    return writeArray(value, len, num, OpcUaType_String, prec);
 }
 
 void

--- a/devOpcuaSup/UaSdk/DataElementUaSdk.h
+++ b/devOpcuaSup/UaSdk/DataElementUaSdk.h
@@ -1065,7 +1065,7 @@ private:
 
     // Write array value for EPICS String / OpcUa_String
     long
-    writeArray (const char **value, const epicsUInt32 len,
+    writeArray (const char *value, const epicsUInt32 len,
                 const epicsUInt32 num,
                 OpcUa_BuiltInType targetType,
                 dbCommon *prec);

--- a/devOpcuaSup/open62541/DataElementOpen62541.h
+++ b/devOpcuaSup/open62541/DataElementOpen62541.h
@@ -1210,7 +1210,7 @@ private:
 
     // Write array value for EPICS String / UA_String
     long
-    writeArray (const char **value, const epicsUInt32 len,
+    writeArray (const char *value, const epicsUInt32 len,
                 const epicsUInt32 num,
                 const UA_DataType *targetType,
                 dbCommon *prec);


### PR DESCRIPTION
Writing arrays of strings (waveform or aao records with `FTVL="STRING"`) wrote only the first element correctly and then just rubbish, possibly crashimg. The reason is that the code used a `char**` assuming a `char*[num]` array of pointers to strings but arrays of strings are actually `char[num][len]`, i.e. one memory block with all the strings with a `char*` to the beginning.