### PR TITLE
uasdk: Fix for bug in "fixConnectionStatus"

### DIFF
--- a/devOpcuaSup/UaSdk/ItemUaSdk.cpp
+++ b/devOpcuaSup/UaSdk/ItemUaSdk.cpp
@@ -219,6 +219,8 @@ ItemUaSdk::setState(const ConnectionStatus state)
     if (auto pd = dataTree.root().lock()) {
         pd->setState(state);
     }
+    if (linkinfo.isItemRecord)
+        recConnector->setState(state);
 }
 
 void


### PR DESCRIPTION
Commit 56cb080e "fix connection state handling" had a bug:
For UaSDK, the item was not setting the state for is own itemRecord.
This broke writing to structures.