### PR TITLE
bugfix: only disable FLNK on non-I/O Intr updates

### DIFF
--- a/devOpcuaSup/RecordConnector.cpp
+++ b/devOpcuaSup/RecordConnector.cpp
@@ -103,7 +103,7 @@ void processCallback (epicsCallback *pcallback, const ProcessReason reason)
 
     // Do not process FLNK on updates if not "I/O Intr"
     SAVE_FLNK(prec);
-    if (reason != writeComplete && prec->scan != menuScanI_O_Intr)
+    if (reason == incomingData && prec->scan != menuScanI_O_Intr)
         DISABLE_FLNK(prec);
     if (prec->pact)
         reProcess(prec);


### PR DESCRIPTION
FLNK was disabled not only on non-I/O Intr updates but as well on non-I/O Intr read (e.g. when reading with scan "1 second").
That was a bug.
