### PR TITLE
fix gcc-15 problem

### DIFF
--- a/devOpcuaSup/iocshIntegration.cpp
+++ b/devOpcuaSup/iocshIntegration.cpp
@@ -1106,8 +1106,6 @@ void opcuaIocshRegister ()
     iocshRegister(&opcuaShowDataFuncDef, opcuaShowDataCallFunc);
 }
 
-extern "C" {
-epicsExportRegistrar(opcuaIocshRegister);
-}
-
 } // namespace
+
+extern "C" { epicsExportRegistrar(opcuaIocshRegister); }

--- a/devOpcuaSup/opcuaItemRecord.cpp
+++ b/devOpcuaSup/opcuaItemRecord.cpp
@@ -203,6 +203,7 @@ rset opcuaItemRSET = {
     get_control_double,
     get_alarm_double
 };
-extern "C" { epicsExportAddress(rset, opcuaItemRSET); }
 
 } // namespace
+
+extern "C" { epicsExportAddress(rset, opcuaItemRSET); }


### PR DESCRIPTION
gcc-15 mangles variables inside namespaces even if they are declared extern "C". That causes linker errors. This is probably a bug in gcc-15. Observed with gcc version 15.1.1.